### PR TITLE
Set scope=provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,12 +108,6 @@
 
             <dependency>
                 <groupId>io.opentracing</groupId>
-                <artifactId>opentracing-noop</artifactId>
-                <version>${opentracing.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.opentracing</groupId>
                 <artifactId>opentracing-util</artifactId>
                 <version>${opentracing.version}</version>
             </dependency>
@@ -171,6 +165,7 @@
         <dependency>
             <groupId>com.typesafe.akka</groupId>
             <artifactId>akka-actor_2.12</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Setting the scope of the target library to "provided". It is a guarantee that the integrating codebase will provide this library, otherwise the instrumentation plugin would be moot if the codebase does not already have this library.